### PR TITLE
Prevent oplog error from crashing the server

### DIFF
--- a/lib/redisdriver.js
+++ b/lib/redisdriver.js
@@ -325,7 +325,6 @@ RedisDriver.prototype._oplogGetOps = function(cName, docName, from, to, callback
     if (err) return callback(err);
     if (ops.length && ops[0].v !== from) {
       return callback('Oplog is returning incorrect ops, v=' + from);
-      // throw Error('Oplog is returning incorrect ops');
     }
 
     for (var i = 0; i < ops.length; i++) {

--- a/lib/redisdriver.js
+++ b/lib/redisdriver.js
@@ -323,7 +323,10 @@ RedisDriver.prototype._oplogGetOps = function(cName, docName, from, to, callback
   var self = this;
   this.oplog.getOps(cName, docName, from, to, function(err, ops) {
     if (err) return callback(err);
-    if (ops.length && ops[0].v !== from) throw Error('Oplog is returning incorrect ops');
+    if (ops.length && ops[0].v !== from) {
+      return callback('Oplog is returning incorrect ops, v=' + from);
+      // throw Error('Oplog is returning incorrect ops');
+    }
 
     for (var i = 0; i < ops.length; i++) {
       ops[i].v = from++;


### PR DESCRIPTION
When you delete the oplog completety it was throwing an error 'Oplog is returning incorrect ops' crashing the server. Instead it should just return a callback with an error crashing only the client.